### PR TITLE
Fix termbox PollEvent goroutine leak

### DIFF
--- a/cmd/termbox/termbox.go
+++ b/cmd/termbox/termbox.go
@@ -10,19 +10,21 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	err := termbox.Init()
 	if err != nil {
+		cancel()
 		panic(err)
 	}
-	defer termbox.Close()
 
-	evQueue := make(chan termbox.Event)
-	goroutine.Start(ctx, func(context.Context) {
-		for {
-			evQueue <- termbox.PollEvent()
-		}
-	})
+	evQueue, wait := startEventLoop(ctx, termbox.PollEvent)
+
+	defer func() {
+		cancel()
+		go termbox.Interrupt()
+		wait()
+		termbox.Close()
+	}()
 
 	width, height := termbox.Size()
 	game := &langton.Game{
@@ -53,6 +55,28 @@ func main() {
 
 		game.Step()
 	}
+}
+
+func startEventLoop(ctx context.Context, poll func() termbox.Event) (evQueue <-chan termbox.Event, wait func()) {
+	ch := make(chan termbox.Event, 1)
+	waiter := goroutine.Start(ctx, func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			ev := poll()
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- ev:
+			}
+		}
+	})
+	evQueue = ch
+	wait = waiter.Wait
+	return
 }
 
 func draw(game *langton.Game) {

--- a/cmd/termbox/termbox_test.go
+++ b/cmd/termbox/termbox_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	termbox "github.com/nsf/termbox-go"
+	"github.com/pierrre/assert"
+)
+
+func TestStartEventLoopForwardEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pollCh := make(chan termbox.Event)
+	poll := func() termbox.Event {
+		return <-pollCh
+	}
+
+	evQueue, wait := startEventLoop(ctx, poll)
+
+	ev := termbox.Event{Type: termbox.EventKey, Key: termbox.KeyEsc}
+	go func() { pollCh <- ev }()
+
+	select {
+	case got := <-evQueue:
+		assert.Equal(t, got, ev)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	cancel()
+	go func() { pollCh <- termbox.Event{} }()
+
+	done := make(chan struct{})
+	go func() {
+		wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for goroutine to exit")
+	}
+}
+
+func TestStartEventLoopExitOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pollCh := make(chan termbox.Event)
+	poll := func() termbox.Event {
+		return <-pollCh
+	}
+
+	_, wait := startEventLoop(ctx, poll)
+
+	cancel()
+	go func() { pollCh <- termbox.Event{Type: termbox.EventInterrupt} }()
+
+	done := make(chan struct{})
+	go func() {
+		wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for goroutine to exit")
+	}
+}


### PR DESCRIPTION
## Bug

The termbox `PollEvent` goroutine ignored `ctx` and never exited.
On keypress the deferred `termbox.Close()` ran concurrently with an active `PollEvent`, then the goroutine blocked forever on the unbuffered `evQueue`.

## Fix

Extracted `startEventLoop` with:
- cancellable context (the goroutine checks `ctx.Done()` before and after each `poll()` call)
- buffered channel (size 1) so the goroutine never blocks indefinitely on send
- `termbox.Interrupt()` in the deferred cleanup to unblock a pending `PollEvent` before calling `wait()` and `termbox.Close()`

## Test coverage

100% for `startEventLoop`.