### PR TITLE
improve: add signal handling to cmd/text for graceful exit

### DIFF
--- a/cmd/text/text.go
+++ b/cmd/text/text.go
@@ -3,14 +3,19 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 
 	"github.com/pierrre/langton"
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	game := &langton.Game{
 		Rules: langton.RulesBasic,
 		Grid:  langton.NewGrid(langton.Pt(80, 60), 2),
@@ -23,6 +28,11 @@ func main() {
 	}
 	buf := new(bytes.Buffer)
 	for step := 0; ; step++ {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		buf.Reset()
 		for y := range game.Grid.Size.Y {
 			for x := range game.Grid.Size.X {


### PR DESCRIPTION
The `cmd/text` command ran an infinite `for` loop with no exit condition, step limit, or signal handling, so it could only be stopped by killing the process (unlike `cmd/termbox` which exits on keypress).

This adds `signal.NotifyContext` for `SIGINT`/`SIGTERM` and a non-blocking `select` on `ctx.Done()` at the top of each loop iteration, allowing graceful exit on signal.