### PR TITLE
docs: expand README with features, usage, and demo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,27 @@
 Langton's ant automaton library.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/pierrre/langton.svg)](https://pkg.go.dev/github.com/pierrre/langton)
+
+## Features
+
+- Grid with configurable number of states
+- Ants with orientation (up, right, down, left)
+- Customizable rules
+- Multiple ants per game
+- Demo commands: `cmd/termbox` (interactive terminal) and `cmd/text` (text output)
+
+## Usage
+
+```bash
+# Local build
+make build
+./build/termbox
+./build/text
+
+# Remote install
+go install github.com/pierrre/langton/cmd/termbox@latest
+go install github.com/pierrre/langton/cmd/text@latest
+
+# Module install
+go get github.com/pierrre/langton@latest
+```


### PR DESCRIPTION
The README was 5 lines with no usage, build, or run instructions, and did not mention the `cmd/termbox` or `cmd/text` demo commands.

This adds:
- A Features section listing the library capabilities (grid, ants, rules, multiple ants, demo commands)
- A Usage section with local build, remote install, and module install instructions for both demo commands